### PR TITLE
Show mouse coordinates below grid area

### DIFF
--- a/index.html
+++ b/index.html
@@ -24,5 +24,6 @@
 
 <img id="traceImage" style="position: absolute; left: 0px;">
 <div id="drawAreaSource"></div>
+<div id="cursorCoordinates"></div>
 </body>
 </html>

--- a/osped.js
+++ b/osped.js
@@ -300,6 +300,8 @@ $(document).mousedown(function(e) {
 });
 $(document).mousemove(function(e) {
 	if (!eventOnDrawArea(e)) return;
+
+	$('#cursorCoordinates').text('x = '+e.x + ', y = ' + e.y);
 	
 	if (local.currentTool == local.editTool)
 	{


### PR DESCRIPTION
This patch displays the current mouse coordinates below the grid, which might be nice for aligning things or trying to get some proportions right.
